### PR TITLE
multi-repo commands

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -22,17 +22,19 @@
 - [Push All](#push-all)
 - [Sync](#sync)
 - [Sync All](#sync-all)
-- [Merge Branch](#merge-branch)
-- [Switch Branch](#switch-branch)
-- [Create Branch](#create-branch)
-- [Delete Branch](#delete-branch)
+- [Merge Branch...](#merge-branch)
+- [Switch Branch...](#switch-branch)
+- [Create Branch...](#create-branch)
+- [Delete Branch...](#delete-branch)
 - [Initialize](#initialize)
 - [Log](#log)
 - [Diff](#diff)
-- [Run Command](#run-command)
+- [Run Command...](#run-command)
 - [Refresh](#refresh)
 
 ## Commit...
+
+`git-menu:commit`
 
 You can commit a single file or multiple files or folders selected in the tree-view.
 This command will bring up a dialog window where you can unselect any files you do not want to commit.
@@ -47,17 +49,25 @@ You then have the following options to commit the message/files:
 
 ## Commit All...
 
+`git-menu:commit-all`
+
 Same as [Commit...](#commit) but will list all changed files in the dialog.
 
 ## Commit Staged...
+
+`git-menu:commit-staged`
 
 Same as [Commit...](#commit) but will list only staged changes in the dialog.
 
 ## Stage Changes
 
+`git-menu:stage-changes`
+
 Stage changes for committing later.
 
 ## Add To Last Commit
+
+`git-menu:add-to-last-commit`
 
 This will add the selected files to the last commit.
 
@@ -65,96 +75,144 @@ If you want to change the message of the last commit you will have to choose [Co
 
 ## Undo Last Commit
 
+`git-menu:undo-last-commit`
+
 This will undo the last commit but save the changes. Like `git reset --mixed HEAD~1`.
 
 ## Discard Changes
+
+`git-menu:discard-changes`
 
 This will discard changes to the selected files.
 
 ## Discard All Changes
 
+`git-menu:discard-all-changes`
+
 This will discard changes to the all files in the repo.
 
 ## Ignore Changes
+
+`git-menu:ignore-changes`
 
 Update the index with the changed version but don't commit the changes. Like `git update-index --assume-unchanged`.
 
 ## Unignore Changes
 
+`git-menu:unignore-changes`
+
 Opposite of [Ignore Changes](#ignore-changes). Like `git update-index --no-assume-unchanged`.
 
 ## Stash Changes
+
+`git-menu:stash-changes`
 
 Save changes and checkout last commit.
 
 ## Unstash Changes
 
+`git-menu:unstash-changes`
+
 Restore changes from last stash.
 
 ## Fetch
+
+`git-menu:fetch`
 
 Fetch from all tracked repos.
 
 ## Fetch All
 
+`git-menu:fetch-all`
+
 Fetch all project repos.
 
 ## Pull
+
+`git-menu:pull`
 
 Pull from tracked upstream.
 
 ## Pull All
 
+`git-menu:pull-all`
+
 Pull all project repos.
 
 ## Push
+
+`git-menu:push`
 
 Push to tracked upstream.
 
 ## Push All
 
+`git-menu:push-all`
+
 Push all project repos.
 
 ## Sync
+
+`git-menu:sync`
 
 Pull then Push.
 
 ## Sync All
 
+`git-menu:sync-all`
+
 Pull then Push all project repos.
 
-## Merge Branch
+## Merge Branch...
+
+`git-menu:merge-branch`
 
 Merge or rebase a branch.
 
-## Switch Branch
+## Switch Branch...
+
+`git-menu:switch-branch`
 
 Checkout a different branch in this repo.
 
-## Create Branch
+## Create Branch...
+
+`git-menu:create-branch`
 
 Create a branch and optionally track/create a remote branch.
 
-## Delete Branch
+## Delete Branch...
+
+`git-menu:delete-branch`
 
 Delete a local and/or remote branch.
 
 ## Initialize
 
+`git-menu:init`
+
 Initialize a git repo for the current project.
 
 ## Log
+
+`git-menu:log`
 
 Show the git log.
 
 ## Diff
 
+`git-menu:diff`
+
 Open the diff patch in a new editor.
 
-## Run Command
+## Run Command...
+
+`git-menu:run-command`
 
 Run any `git` command with selected `%files%` as an argument.
 
 ## Refresh
+
+`git-menu:refresh`
 
 Refresh the git status in Atom.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -6,26 +6,31 @@
 - [Commit All...](#commit-all)
 - [Commit Staged...](#commit-staged)
 - [Stage Changes](#stage-changes)
+- [Add To Last Commit](#add-to-last-commit)
+- [Undo Last Commit](#undo-last-commit)
 - [Discard Changes](#discard-changes)
 - [Discard All Changes](#discard-all-changes)
 - [Ignore Changes](#ignore-changes)
 - [Unignore Changes](#unignore-changes)
 - [Stash Changes](#stash-changes)
 - [Unstash Changes](#unstash-changes)
-- [Add To Last Commit](#add-to-last-commit)
-- [Undo Last Commit](#undo-last-commit)
+- [Fetch](#fetch)
+- [Fetch All](#fetch-all)
+- [Pull](#pull)
+- [Pull All](#pull-all)
+- [Push](#push)
+- [Push All](#push-all)
+- [Sync](#sync)
+- [Sync All](#sync-all)
+- [Merge Branch](#merge-branch)
 - [Switch Branch](#switch-branch)
 - [Create Branch](#create-branch)
-- [Merge Branch](#merge-branch)
-- [Pull](#pull)
-- [Push](#push)
-- [Sync](#sync)
+- [Delete Branch](#delete-branch)
 - [Initialize](#initialize)
-- [Refresh](#refresh)
-- [Fetch](#fetch)
-- [Run Command](#run-command)
 - [Log](#log)
 - [Diff](#diff)
+- [Run Command](#run-command)
+- [Refresh](#refresh)
 
 ## Commit...
 
@@ -52,6 +57,16 @@ Same as [Commit...](#commit) but will list only staged changes in the dialog.
 
 Stage changes for committing later.
 
+## Add To Last Commit
+
+This will add the selected files to the last commit.
+
+If you want to change the message of the last commit you will have to choose [Commit...](#commit) or [Commit All...](#commit-all).
+
+## Undo Last Commit
+
+This will undo the last commit but save the changes. Like `git reset --mixed HEAD~1`.
+
 ## Discard Changes
 
 This will discard changes to the selected files.
@@ -76,15 +91,41 @@ Save changes and checkout last commit.
 
 Restore changes from last stash.
 
-## Add To Last Commit
+## Fetch
 
-This will add the selected files to the last commit.
+Fetch from all tracked repos.
 
-If you want to change the message of the last commit you will have to choose [Commit...](#commit) or [Commit All...](#commit-all).
+## Fetch All
 
-## Undo Last Commit
+Fetch all project repos.
 
-This will undo the last commit but save the changes. Like `git reset --mixed HEAD~1`.
+## Pull
+
+Pull from tracked upstream.
+
+## Pull All
+
+Pull all project repos.
+
+## Push
+
+Push to tracked upstream.
+
+## Push All
+
+Push all project repos.
+
+## Sync
+
+Pull then Push.
+
+## Sync All
+
+Pull then Push all project repos.
+
+## Merge Branch
+
+Merge or rebase a branch.
 
 ## Switch Branch
 
@@ -94,37 +135,13 @@ Checkout a different branch in this repo.
 
 Create a branch and optionally track/create a remote branch.
 
-## Merge Branch
+## Delete Branch
 
-Merge or rebase a branch.
-
-## Pull
-
-Pull from tracked upstream.
-
-## Push
-
-Push to tracked upstream.
-
-## Sync
-
-Pull then Push.
+Delete a local and/or remote branch.
 
 ## Initialize
 
 Initialize a git repo for the current project.
-
-## Refresh
-
-Refresh the git status in Atom.
-
-## Fetch
-
-Fetch from all tracked repos.
-
-## Run Command
-
-Run any `git` command with selected `%files%` as an argument.
 
 ## Log
 
@@ -133,3 +150,11 @@ Show the git log.
 ## Diff
 
 Open the diff patch in a new editor.
+
+## Run Command
+
+Run any `git` command with selected `%files%` as an argument.
+
+## Refresh
+
+Refresh the git status in Atom.

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -8,23 +8,27 @@ import addToLastCommit from "./commands/add-to-last-commit";
 import undoLastCommit from "./commands/undo-last-commit";
 import discardChanges from "./commands/discard-changes";
 import discardAllChanges from "./commands/discard-all-changes";
+import ignoreChanges from "./commands/ignore-changes";
+import unignoreChanges from "./commands/unignore-changes";
+import stashChanges from "./commands/stash-changes";
+import unstashChanges from "./commands/unstash-changes";
+import fetch from "./commands/fetch";
+import fetchAll from "./commands/fetch-all";
 import pull from "./commands/pull";
+import pullAll from "./commands/pull-all";
 import push from "./commands/push";
+import pushAll from "./commands/push-all";
 import sync from "./commands/sync";
+import syncAll from "./commands/sync-all";
 import mergeBranch from "./commands/merge-branch";
 import switchBranch from "./commands/switch-branch";
 import createBranch from "./commands/create-branch";
 import deleteBranch from "./commands/delete-branch";
-import ignoreChanges from "./commands/ignore-changes";
-import unignoreChanges from "./commands/unignore-changes";
 import init from "./commands/init";
-import refresh from "./commands/refresh";
-import fetch from "./commands/fetch";
-import stashChanges from "./commands/stash-changes";
-import unstashChanges from "./commands/unstash-changes";
-import runCommand from "./commands/run-command";
 import log from "./commands/log";
 import diff from "./commands/diff";
+import runCommand from "./commands/run-command";
+import refresh from "./commands/refresh";
 
 /**
  * These commands will be added to the context menu in the order they appear here.
@@ -54,21 +58,25 @@ export default {
 	"undo-last-commit": undoLastCommit,
 	"discard-changes": discardChanges,
 	"discard-all-changes": discardAllChanges,
+	"ignore-changes": ignoreChanges,
+	"unignore-changes": unignoreChanges,
+	"stash-changes": stashChanges,
+	"unstash-changes": unstashChanges,
+	"fetch": fetch,
+	"fetch-all": fetchAll,
 	"pull": pull,
+	"pull-all": pullAll,
 	"push": push,
+	"push-all": pushAll,
 	"sync": sync,
+	"sync-all": syncAll,
 	"merge-branch": mergeBranch,
 	"switch-branch": switchBranch,
 	"create-branch": createBranch,
 	"delete-branch": deleteBranch,
-	"ignore-changes": ignoreChanges,
-	"unignore-changes": unignoreChanges,
 	"init": init,
-	"refresh": refresh,
-	"fetch": fetch,
-	"stash-changes": stashChanges,
-	"unstash-changes": unstashChanges,
-	"run-command": runCommand,
 	"log": log,
 	"diff": diff,
+	"run-command": runCommand,
+	"refresh": refresh,
 };

--- a/lib/commands/fetch-all.js
+++ b/lib/commands/fetch-all.js
@@ -12,12 +12,13 @@ export default {
 	},
 	async command(filePaths, statusBar, git = gitCmd, notifications = Notifications, title = "Fetch All") {
 		const fetches = await Promise.all(atom.project.getPaths().map(root => {
-			return fetch([root], statusBar, git, notifications).catch((ex) => {
-				console.log(ex);
+			return fetch([root], statusBar, git, notifications).catch((err) => {
+				const message = (err.stack ? err.stack : err.toString());
+				notifications.addError("Context Git: Fetch", `${root}\n\n${message}`);
 				return null;
 			});
 		}));
-		console.log(fetches);
+
 		const failed = fetches.filter(p => !p);
 		let num = "all";
 		if (failed.length > 0) {

--- a/lib/commands/fetch-all.js
+++ b/lib/commands/fetch-all.js
@@ -12,9 +12,12 @@ export default {
 	},
 	async command(filePaths, statusBar, git = gitCmd, notifications = Notifications, title = "Fetch All") {
 		const fetches = await Promise.all(atom.project.getPaths().map(root => {
-			return fetch(root, statusBar, git, notifications).catch(() => null);
+			return fetch([root], statusBar, git, notifications).catch((ex) => {
+				console.log(ex);
+				return null;
+			});
 		}));
-
+		console.log(fetches);
 		const failed = fetches.filter(p => !p);
 		let num = "all";
 		if (failed.length > 0) {

--- a/lib/commands/fetch-all.js
+++ b/lib/commands/fetch-all.js
@@ -1,0 +1,29 @@
+/** @babel */
+
+import gitCmd from "../git-cmd";
+import Notifications from "../Notifications";
+import {command as fetch} from "./fetch";
+
+export default {
+	label: "Fetch All",
+	description: "Fetch all project repos",
+	confirm: {
+		message: "Are you sure you want to fetch all project repos?"
+	},
+	async command(filePaths, statusBar, git = gitCmd, notifications = Notifications, title = "Fetch All") {
+		const fetches = await Promise.all(atom.project.getPaths().map(root => {
+			return fetch(root, statusBar, git, notifications).catch(() => null);
+		}));
+
+		const failed = fetches.filter(p => !p);
+		let num = "all";
+		if (failed.length > 0) {
+			num = fetches.length - failed.length;
+		}
+
+		return {
+			title,
+			message: `Fetched ${num} repos.`,
+		};
+	}
+};

--- a/lib/commands/pull-all.js
+++ b/lib/commands/pull-all.js
@@ -12,7 +12,11 @@ export default {
 	},
 	async command(filePaths, statusBar, git = gitCmd, notifications = Notifications, title = "Pull All") {
 		const pulls = await Promise.all(atom.project.getPaths().map(root => {
-			return pull([root], statusBar, git, notifications).catch(() => null);
+			return pull([root], statusBar, git, notifications).catch((err) => {
+				const message = (err.stack ? err.stack : err.toString());
+				notifications.addError("Context Git: Pull", `${root}\n\n${message}`);
+				return null;
+			});
 		}));
 
 		const failed = pulls.filter(p => !p);

--- a/lib/commands/pull-all.js
+++ b/lib/commands/pull-all.js
@@ -1,0 +1,29 @@
+/** @babel */
+
+import gitCmd from "../git-cmd";
+import Notifications from "../Notifications";
+import {command as pull} from "./pull";
+
+export default {
+	label: "Pull All",
+	description: "Pull all project repos",
+	confirm: {
+		message: "Are you sure you want to pull all project repos?"
+	},
+	async command(filePaths, statusBar, git = gitCmd, notifications = Notifications, title = "Pull All") {
+		const pulls = await Promise.all(atom.project.getPaths().map(root => {
+			return pull(root, statusBar, git, notifications).catch(() => null);
+		}));
+
+		const failed = pulls.filter(p => !p);
+		let num = "all";
+		if (failed.length > 0) {
+			num = pulls.length - failed.length;
+		}
+
+		return {
+			title,
+			message: `Pulled ${num} repos.`,
+		};
+	},
+};

--- a/lib/commands/pull-all.js
+++ b/lib/commands/pull-all.js
@@ -12,7 +12,7 @@ export default {
 	},
 	async command(filePaths, statusBar, git = gitCmd, notifications = Notifications, title = "Pull All") {
 		const pulls = await Promise.all(atom.project.getPaths().map(root => {
-			return pull(root, statusBar, git, notifications).catch(() => null);
+			return pull([root], statusBar, git, notifications).catch(() => null);
 		}));
 
 		const failed = pulls.filter(p => !p);

--- a/lib/commands/push-all.js
+++ b/lib/commands/push-all.js
@@ -1,0 +1,29 @@
+/** @babel */
+
+import gitCmd from "../git-cmd";
+import Notifications from "../Notifications";
+import {command as push} from "./push";
+
+export default {
+	label: "Push All",
+	description: "Push all project repos",
+	confirm: {
+		message: "Are you sure you want to push all projectrepos?"
+	},
+	async command(filePaths, statusBar, git = gitCmd, notifications = Notifications, title = "Push All") {
+		const pushes = await Promise.all(atom.project.getPaths().map(root => {
+			return push(root, statusBar, git, notifications).catch(() => null);
+		}));
+
+		const failed = pushes.filter(p => !p);
+		let num = "all";
+		if (failed.length > 0) {
+			num = pushes.length - failed.length;
+		}
+
+		return {
+			title,
+			message: `Pushed ${num} repos.`,
+		};
+	},
+};

--- a/lib/commands/push-all.js
+++ b/lib/commands/push-all.js
@@ -12,7 +12,7 @@ export default {
 	},
 	async command(filePaths, statusBar, git = gitCmd, notifications = Notifications, title = "Push All") {
 		const pushes = await Promise.all(atom.project.getPaths().map(root => {
-			return push(root, statusBar, git, notifications).catch(() => null);
+			return push([root], statusBar, git, notifications).catch(() => null);
 		}));
 
 		const failed = pushes.filter(p => !p);

--- a/lib/commands/push-all.js
+++ b/lib/commands/push-all.js
@@ -12,7 +12,11 @@ export default {
 	},
 	async command(filePaths, statusBar, git = gitCmd, notifications = Notifications, title = "Push All") {
 		const pushes = await Promise.all(atom.project.getPaths().map(root => {
-			return push([root], statusBar, git, notifications).catch(() => null);
+			return push([root], statusBar, git, notifications).catch((err) => {
+				const message = (err.stack ? err.stack : err.toString());
+				notifications.addError("Context Git: Push", `${root}\n\n${message}`);
+				return null;
+			});
 		}));
 
 		const failed = pushes.filter(p => !p);

--- a/lib/commands/sync-all.js
+++ b/lib/commands/sync-all.js
@@ -12,7 +12,11 @@ export default {
 	},
 	async command(filePaths, statusBar, git = gitCmd, notifications = Notifications, title = "Sync All") {
 		const syncs = await Promise.all(atom.project.getPaths().map(root => {
-			return sync([root], statusBar, git, notifications).catch(() => null);
+			return sync([root], statusBar, git, notifications).catch((err) => {
+				const message = (err.stack ? err.stack : err.toString());
+				notifications.addError("Context Git: Sync", `${root}\n\n${message}`);
+				return null;
+			});
 		}));
 
 		const failed = syncs.filter(p => !p);

--- a/lib/commands/sync-all.js
+++ b/lib/commands/sync-all.js
@@ -1,0 +1,29 @@
+/** @babel */
+
+import gitCmd from "../git-cmd";
+import Notifications from "../Notifications";
+import {command as sync} from "./sync";
+
+export default {
+	label: "Sync All",
+	description: "Pull then push all project repos",
+	confirm: {
+		message: "Are you sure you want to sync all project repos?"
+	},
+	async command(filePaths, statusBar, git = gitCmd, notifications = Notifications, title = "Sync All") {
+		const syncs = await Promise.all(atom.project.getPaths().map(root => {
+			return sync(root, statusBar, git, notifications).catch(() => null);
+		}));
+
+		const failed = syncs.filter(p => !p);
+		let num = "all";
+		if (failed.length > 0) {
+			num = syncs.length - failed.length;
+		}
+
+		return {
+			title,
+			message: `Synced ${num} repos.`,
+		};
+	},
+};

--- a/lib/commands/sync-all.js
+++ b/lib/commands/sync-all.js
@@ -12,7 +12,7 @@ export default {
 	},
 	async command(filePaths, statusBar, git = gitCmd, notifications = Notifications, title = "Sync All") {
 		const syncs = await Promise.all(atom.project.getPaths().map(root => {
-			return sync(root, statusBar, git, notifications).catch(() => null);
+			return sync([root], statusBar, git, notifications).catch(() => null);
 		}));
 
 		const failed = syncs.filter(p => !p);

--- a/spec/commands/fetch-all-spec.js
+++ b/spec/commands/fetch-all-spec.js
@@ -1,0 +1,28 @@
+/** @babel */
+
+import fetchAll from "../../lib/commands/fetch-all";
+import fetch from "../../lib/commands/fetch";
+import {removeGitRoot, createGitRoot} from "../mocks";
+
+describe("fetch-all", function () {
+
+	beforeEach(async function () {
+		await atom.packages.activatePackage("git-menu");
+		this.gitRoot1 = await createGitRoot();
+		this.gitRoot2 = await createGitRoot();
+		atom.project.setPaths([this.gitRoot1, this.gitRoot2]);
+	});
+
+	afterEach(async function () {
+		await removeGitRoot(this.gitRoot1);
+		await removeGitRoot(this.gitRoot2);
+	});
+
+	it("should call fetch with project folders", async function () {
+		spyOn(fetch, "command").and.callFake(() => Promise.resolve());
+		await fetchAll.command();
+		expect(fetch.command).toHaveBeenCalledTimes(2);
+		expect(fetch.command.calls.argsFor(0)[0]).toEqual(this.gitRoot1);
+		expect(fetch.command.calls.argsFor(1)[0]).toEqual(this.gitRoot2);
+	});
+});

--- a/spec/commands/fetch-all-spec.js
+++ b/spec/commands/fetch-all-spec.js
@@ -22,7 +22,7 @@ describe("fetch-all", function () {
 		spyOn(fetch, "command").and.callFake(() => Promise.resolve());
 		await fetchAll.command();
 		expect(fetch.command).toHaveBeenCalledTimes(2);
-		expect(fetch.command.calls.argsFor(0)[0]).toEqual(this.gitRoot1);
-		expect(fetch.command.calls.argsFor(1)[0]).toEqual(this.gitRoot2);
+		expect(fetch.command.calls.argsFor(0)[0]).toEqual([this.gitRoot1]);
+		expect(fetch.command.calls.argsFor(1)[0]).toEqual([this.gitRoot2]);
 	});
 });

--- a/spec/commands/fetch-spec.js
+++ b/spec/commands/fetch-spec.js
@@ -1,0 +1,47 @@
+/** @babel */
+
+import fetch from "../../lib/commands/fetch";
+import Notifications from "../../lib/Notifications";
+import {getFilePath, statusBar, mockGit, removeGitRoot, createGitRoot, files} from "../mocks";
+
+describe("fetch", function () {
+
+	beforeEach(async function () {
+		await atom.packages.activatePackage("git-menu");
+		this.gitRoot = await createGitRoot();
+
+		this.filePaths = getFilePath(this.gitRoot, [files.t1]);
+		this.git = mockGit({
+			rootDir: Promise.resolve(this.gitRoot),
+			fetch: Promise.resolve("fetch result"),
+		});
+	});
+
+	afterEach(async function () {
+		await removeGitRoot(this.gitRoot);
+	});
+
+	it("should show fetching... in status bar", async function () {
+		spyOn(statusBar, "show").and.callThrough();
+		await fetch.command(this.filePaths, statusBar, this.git, Notifications);
+		expect(statusBar.show).toHaveBeenCalledWith("Fetching...");
+	});
+
+	it("should call git.fetch", async function () {
+		spyOn(this.git, "fetch").and.callThrough();
+		await fetch.command(this.filePaths, statusBar, this.git, Notifications);
+		expect(this.git.fetch).toHaveBeenCalledWith(this.gitRoot);
+	});
+
+	it("should show git notification for fetch results", async function () {
+		spyOn(Notifications, "addGit").and.callThrough();
+		await fetch.command(this.filePaths, statusBar, this.git, Notifications);
+		expect(Notifications.addGit).toHaveBeenCalledWith("Fetch", "fetch result");
+	});
+
+	it("should return fetched.'", async function () {
+		const ret = await fetch.command(this.filePaths, statusBar, this.git, Notifications);
+		expect(ret.message).toBe("Fetched.");
+	});
+
+});

--- a/spec/commands/pull-all-spec.js
+++ b/spec/commands/pull-all-spec.js
@@ -1,0 +1,28 @@
+/** @babel */
+
+import pullAll from "../../lib/commands/pull-all";
+import pull from "../../lib/commands/pull";
+import {removeGitRoot, createGitRoot} from "../mocks";
+
+describe("pull-all", function () {
+
+	beforeEach(async function () {
+		await atom.packages.activatePackage("git-menu");
+		this.gitRoot1 = await createGitRoot();
+		this.gitRoot2 = await createGitRoot();
+		atom.project.setPaths([this.gitRoot1, this.gitRoot2]);
+	});
+
+	afterEach(async function () {
+		await removeGitRoot(this.gitRoot1);
+		await removeGitRoot(this.gitRoot2);
+	});
+
+	it("should call pull with project folders", async function () {
+		spyOn(pull, "command").and.callFake(() => Promise.resolve());
+		await pullAll.command();
+		expect(pull.command).toHaveBeenCalledTimes(2);
+		expect(pull.command.calls.argsFor(0)[0]).toEqual(this.gitRoot1);
+		expect(pull.command.calls.argsFor(1)[0]).toEqual(this.gitRoot2);
+	});
+});

--- a/spec/commands/pull-all-spec.js
+++ b/spec/commands/pull-all-spec.js
@@ -22,7 +22,7 @@ describe("pull-all", function () {
 		spyOn(pull, "command").and.callFake(() => Promise.resolve());
 		await pullAll.command();
 		expect(pull.command).toHaveBeenCalledTimes(2);
-		expect(pull.command.calls.argsFor(0)[0]).toEqual(this.gitRoot1);
-		expect(pull.command.calls.argsFor(1)[0]).toEqual(this.gitRoot2);
+		expect(pull.command.calls.argsFor(0)[0]).toEqual([this.gitRoot1]);
+		expect(pull.command.calls.argsFor(1)[0]).toEqual([this.gitRoot2]);
 	});
 });

--- a/spec/commands/push-all-spec.js
+++ b/spec/commands/push-all-spec.js
@@ -22,7 +22,7 @@ describe("push-all", function () {
 		spyOn(push, "command").and.callFake(() => Promise.resolve());
 		await pushAll.command();
 		expect(push.command).toHaveBeenCalledTimes(2);
-		expect(push.command.calls.argsFor(0)[0]).toEqual(this.gitRoot1);
-		expect(push.command.calls.argsFor(1)[0]).toEqual(this.gitRoot2);
+		expect(push.command.calls.argsFor(0)[0]).toEqual([this.gitRoot1]);
+		expect(push.command.calls.argsFor(1)[0]).toEqual([this.gitRoot2]);
 	});
 });

--- a/spec/commands/push-all-spec.js
+++ b/spec/commands/push-all-spec.js
@@ -1,0 +1,28 @@
+/** @babel */
+
+import pushAll from "../../lib/commands/push-all";
+import push from "../../lib/commands/push";
+import {removeGitRoot, createGitRoot} from "../mocks";
+
+describe("push-all", function () {
+
+	beforeEach(async function () {
+		await atom.packages.activatePackage("git-menu");
+		this.gitRoot1 = await createGitRoot();
+		this.gitRoot2 = await createGitRoot();
+		atom.project.setPaths([this.gitRoot1, this.gitRoot2]);
+	});
+
+	afterEach(async function () {
+		await removeGitRoot(this.gitRoot1);
+		await removeGitRoot(this.gitRoot2);
+	});
+
+	it("should call push with project folders", async function () {
+		spyOn(push, "command").and.callFake(() => Promise.resolve());
+		await pushAll.command();
+		expect(push.command).toHaveBeenCalledTimes(2);
+		expect(push.command.calls.argsFor(0)[0]).toEqual(this.gitRoot1);
+		expect(push.command.calls.argsFor(1)[0]).toEqual(this.gitRoot2);
+	});
+});

--- a/spec/commands/sync-all-spec.js
+++ b/spec/commands/sync-all-spec.js
@@ -22,7 +22,7 @@ describe("sync-all", function () {
 		spyOn(sync, "command").and.callFake(() => Promise.resolve());
 		await syncAll.command();
 		expect(sync.command).toHaveBeenCalledTimes(2);
-		expect(sync.command.calls.argsFor(0)[0]).toEqual(this.gitRoot1);
-		expect(sync.command.calls.argsFor(1)[0]).toEqual(this.gitRoot2);
+		expect(sync.command.calls.argsFor(0)[0]).toEqual([this.gitRoot1]);
+		expect(sync.command.calls.argsFor(1)[0]).toEqual([this.gitRoot2]);
 	});
 });

--- a/spec/commands/sync-all-spec.js
+++ b/spec/commands/sync-all-spec.js
@@ -1,0 +1,28 @@
+/** @babel */
+
+import syncAll from "../../lib/commands/sync-all";
+import sync from "../../lib/commands/sync";
+import {removeGitRoot, createGitRoot} from "../mocks";
+
+describe("sync-all", function () {
+
+	beforeEach(async function () {
+		await atom.packages.activatePackage("git-menu");
+		this.gitRoot1 = await createGitRoot();
+		this.gitRoot2 = await createGitRoot();
+		atom.project.setPaths([this.gitRoot1, this.gitRoot2]);
+	});
+
+	afterEach(async function () {
+		await removeGitRoot(this.gitRoot1);
+		await removeGitRoot(this.gitRoot2);
+	});
+
+	it("should call sync with project folders", async function () {
+		spyOn(sync, "command").and.callFake(() => Promise.resolve());
+		await syncAll.command();
+		expect(sync.command).toHaveBeenCalledTimes(2);
+		expect(sync.command.calls.argsFor(0)[0]).toEqual(this.gitRoot1);
+		expect(sync.command.calls.argsFor(1)[0]).toEqual(this.gitRoot2);
+	});
+});

--- a/spec/commands/sync-spec.js
+++ b/spec/commands/sync-spec.js
@@ -1,0 +1,28 @@
+/** @babel */
+
+import sync from "../../lib/commands/sync";
+import pull from "../../lib/commands/pull";
+import push from "../../lib/commands/push";
+import {getFilePath, removeGitRoot, createGitRoot, files} from "../mocks";
+
+describe("sync", function () {
+
+	beforeEach(async function () {
+		await atom.packages.activatePackage("git-menu");
+		this.gitRoot = await createGitRoot();
+
+		this.filePaths = getFilePath(this.gitRoot, [files.t1]);
+	});
+
+	afterEach(async function () {
+		await removeGitRoot(this.gitRoot);
+	});
+
+	it("should call pull and push", async function () {
+		spyOn(pull, "command").and.callFake(() => Promise.resolve());
+		spyOn(push, "command").and.callFake(() => Promise.resolve());
+		await sync.command(this.filePaths);
+		expect(pull.command.calls.mostRecent().args[0]).toEqual(this.filePaths);
+		expect(push.command.calls.mostRecent().args[0]).toEqual(this.filePaths);
+	});
+});


### PR DESCRIPTION
### Commands

Adds the following commands that work on multiple repos:
- `Fetch All`
- `Pull All`
- `Push All`
- `Sync All`

### Checks

- [x] Command issue: fixes #114 
- [x] Command added to docs
- [x] Tests added
