### PR TITLE
introduce a fix for windows smb share

### DIFF
--- a/lib/git-cmd.js
+++ b/lib/git-cmd.js
@@ -132,9 +132,11 @@ export default {
 	async rootDir(cwd) {
 		const result = await this.cmd(cwd, ["rev-parse", "--show-toplevel"], "", false);
 		const cleanResult = result.trimRight().replace(/[\\/]/g, path.sep);
-		if(cleanResult.startsWith('\\\\') || cleanResult.startsWith('smb://')) {
-			return cwd
-		} else return cleanResult
+		if (cleanResult.startsWith("\\\\") || cleanResult.startsWith("smb://")) {
+			return cwd;
+		}
+
+		return cleanResult;
 	},
 
 	/**

--- a/lib/git-cmd.js
+++ b/lib/git-cmd.js
@@ -131,7 +131,10 @@ export default {
 	 */
 	async rootDir(cwd) {
 		const result = await this.cmd(cwd, ["rev-parse", "--show-toplevel"], "", false);
-		return result.trimRight().replace(/[\\/]/g, path.sep);
+		const cleanResult = result.trimRight().replace(/[\\/]/g, path.sep);
+		if(cleanResult.startsWith('\\\\') || cleanResult.startsWith('smb://')) {
+			return cwd
+		} else return cleanResult
 	},
 
 	/**


### PR DESCRIPTION
if a windows share (smb) is mounted on windows like a drive (ex: A:\ ) the dir passed  is decoded to his 'UNC' version \\myshare\, this lead to a refuse of git to operate because unsupported, but if the dir isn't converted and is passed like a drive to git, the operation will run succesfully.