### PR TITLE
fix: check for 'main' or 'default' as default branch names

### DIFF
--- a/lib/commands/delete-branch.js
+++ b/lib/commands/delete-branch.js
@@ -24,19 +24,22 @@ export default {
 		await helper.checkGitLock(root);
 		const results = [];
 		if (branch.selected) {
-			// if branch is current branch then checkout master first
-			if (branch.name === "master") {
-				branches = await git.branches(root);
-				const br = branches.find(b => !b.selected && b.local);
-				if (br) {
-					results.push(await git.checkoutBranch(root, br.name));
+			const defaultBranchName = helper.getDefaultBranch(branches);
+			if (defaultBranchName) {
+				// if branch is current branch then checkout master first
+				if (branch.name === defaultBranchName) {
+					branches = await git.branches(root);
+					const br = branches.find(b => !b.selected && b.local);
+					if (br) {
+						results.push(await git.checkoutBranch(root, br.name));
+					}
+				} else {
+					results.push(await git.checkoutBranch(root, defaultBranchName));
 				}
-			} else {
-				results.push(await git.checkoutBranch(root, "master"));
-			}
 
-			if (results.length > 0) {
-				helper.refreshAtom(root);
+				if (results.length > 0) {
+					helper.refreshAtom(root);
+				}
 			}
 		}
 

--- a/lib/dialogs/MergeBranchDialog.js
+++ b/lib/dialogs/MergeBranchDialog.js
@@ -3,6 +3,7 @@
 /** @jsx etch.dom */
 
 import gitCmd from "../git-cmd";
+import helper from "../helper";
 import Dialog from "./Dialog";
 import etch from "etch";
 import Notifications from "../Notifications";
@@ -31,8 +32,8 @@ export default class MergeBranchDialog extends Dialog {
 
 		const selectedBranch = state.branches.find(b => b.selected);
 		state.rootBranch = selectedBranch ? selectedBranch.name : "";
-		const masterBranch = state.branches.find(b => b.name === "master");
-		state.mergeBranch = masterBranch ? masterBranch.name : "";
+		const defaultBranch = helper.getDefaultBranch(state.branches);
+		state.mergeBranch = defaultBranch ? defaultBranch.name : "";
 
 		return state;
 	}

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -27,6 +27,28 @@ export default {
 	},
 
 	/**
+	 * Get Default Branch
+	 * @param  {object[]} branches Array of branch objects
+	 * @return {object} Branch object
+	 */
+	getDefaultBranch(branches) {
+		const defaultBranchNames = [
+			"master",
+			"main",
+			"default",
+		];
+
+		for (const branchName of defaultBranchNames) {
+			const defaultBranch = branches.find(b => b.name === branchName);
+			if (defaultBranch) {
+				return defaultBranch;
+			}
+		}
+
+		return null;
+	},
+
+	/**
 	 * Get the paths of the context target
 	 * @param  {EventTarget} target The context target
 	 * @return {string[]} The selected paths for the target

--- a/spec/helper-spec.js
+++ b/spec/helper-spec.js
@@ -87,6 +87,52 @@ describe("helper", function () {
 
 	});
 
+	describe("getDefaultBranch", () => {
+
+		it("should return master branch", async function () {
+			const branches = [
+				{name: "test"},
+				{name: "default"},
+				{name: "main"},
+				{name: "master"},
+			];
+			const branch = helper.getDefaultBranch(branches);
+
+			expect(branch.name).toBe("master");
+		});
+
+		it("should return main branch", async function () {
+			const branches = [
+				{name: "test"},
+				{name: "default"},
+				{name: "main"},
+			];
+			const branch = helper.getDefaultBranch(branches);
+
+			expect(branch.name).toBe("main");
+		});
+
+		it("should return default branch", async function () {
+			const branches = [
+				{name: "test"},
+				{name: "default"},
+			];
+			const branch = helper.getDefaultBranch(branches);
+
+			expect(branch.name).toBe("default");
+		});
+
+		it("should return null", async function () {
+			const branches = [
+				{name: "test"},
+			];
+			const branch = helper.getDefaultBranch(branches);
+
+			expect(branch).toBe(null);
+		});
+
+	});
+
 	describe("getFilesInDir", function () {
 
 		beforeEach(async function () {


### PR DESCRIPTION
Allow default branch to be named "master", "main", or "default",